### PR TITLE
fix: disable queue autoplay when video belongs to playlist

### DIFF
--- a/components/page/MainPageContent.tsx
+++ b/components/page/MainPageContent.tsx
@@ -224,7 +224,8 @@ export const MainPageContent: React.FC<{ contentJs: string }> = ({ contentJs }) 
       case 'playback-end':
         const videoId = getVideoId(uiState.pageUrl)
         const bookmarks = queue$.bookmarks.get()
-        if (videoId && bookmarks.length) {
+        const hasPlaylistParam = uiState.pageUrl.includes('list=')
+        if (videoId && bookmarks.length && !hasPlaylistParam) {
           const queueIndex = bookmarks.findIndex((x) => getVideoId(x.url) == videoId)
           if (queueIndex != bookmarks.length - 1) {
             ui$.url.set(bookmarks[queueIndex + 1].url)


### PR DESCRIPTION
check for a `list` parameter to detect if the current video is in a playlist and disable queue autoplay if it is.

closes #178 