### PR TITLE
android: do not restore last playing when opened from link

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -117,6 +117,14 @@ export default function HomeScreen() {
     return () => subscription.remove()
   }, [])
 
+  useEffect(() => {
+    void Linking.getInitialURL().then((url) => {
+      if (url) {
+        openSharedUrl(url)
+      }
+    })
+  }, [])
+
   useObserveEffect(ui$.url, () => {
     ui$.queueModalOpen.set(false)
   })


### PR DESCRIPTION
Cold start from a YouTube link in another app always resumed the last-played video instead of opening the linked video, even with "Restore last playing on start" enabled (#158). The same root cause — incoming intent URLs being dropped on cold start — is also why deep links were ignored entirely (#188).

`Linking.getInitialURL()` was never called in `app/index.tsx`, so the Android intent URL was dropped on cold start. The first webview `onload` then unconditionally triggered `window.NouTube.restoreLastPlaying()` because the only guard was the user setting.

Call `Linking.getInitialURL()` on mount and route through the existing `openSharedUrl` path. When a deep link resolves before `onload`, the existing `ui$.url` observer in `MainPageContent.tsx` already flips the `restored` flag so `restoreLastPlaying` is skipped — no extra guard needed.

Warm-start Linking events, share-intent path, and the user-facing setting are unchanged.

Closes #158
Closes #188