### PR TITLE
android: go home instead of closing when back is pressed with no webview history

### DIFF
--- a/modules/nou-tube-view/android/src/main/java/expo/modules/noutubeview/NouTubeView.kt
+++ b/modules/nou-tube-view/android/src/main/java/expo/modules/noutubeview/NouTubeView.kt
@@ -101,6 +101,7 @@ class NouTubeView(context: Context, appContext: AppContext) : ExpoView(context, 
   private var pageUrl = ""
   private var customView: View? = null
   private var pullToRefreshEnabled = true
+  private var pendingClearHistory = false
   private lateinit var orientationListener: NouOrientationListener
   private val swipeRefreshLayout = SwipeRefreshLayout(context).apply {
     layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
@@ -192,6 +193,10 @@ class NouTubeView(context: Context, appContext: AppContext) : ExpoView(context, 
 
           override fun onPageFinished(view: WebView, url: String) {
             swipeRefreshLayout.isRefreshing = false
+            if (pendingClearHistory) {
+              pendingClearHistory = false
+              view.clearHistory()
+            }
           }
 
           override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
@@ -327,6 +332,13 @@ class NouTubeView(context: Context, appContext: AppContext) : ExpoView(context, 
   fun setPullToRefreshEnabled(enabled: Boolean) {
     pullToRefreshEnabled = enabled
     updateSwipeRefreshEnabled()
+  }
+
+  fun requestGoHome() {
+    val home = Uri.parse(webView.url ?: "").buildUpon()?.path("/")?.clearQuery()?.fragment(null)?.build()?.toString()
+    if (home.isNullOrBlank()) return
+    pendingClearHistory = true
+    webView.loadUrl(home)
   }
 
   private fun updateSwipeRefreshEnabled() {

--- a/modules/nou-tube-view/android/src/main/java/expo/modules/noutubeview/NouTubeViewModule.kt
+++ b/modules/nou-tube-view/android/src/main/java/expo/modules/noutubeview/NouTubeViewModule.kt
@@ -205,7 +205,12 @@ class NouTubeViewModule : Module() {
         if (webView.canGoBack()) {
           webView.goBack()
         } else {
-          view.currentActivity?.finish()
+          val path = Uri.parse(webView.url ?: "").path ?: ""
+          if (path.isEmpty() || path == "/") {
+            view.currentActivity?.finish()
+          } else {
+            view.requestGoHome()
+          }
         }
       }
 


### PR DESCRIPTION
When the app was opened directly on a video (e.g. via a YouTube deep link, or via "Restore last playing on start" resuming a watch URL), there was no WebView back history to return to, so pressing the hardware back button called `Activity.finish()` and closed the app instead of landing on the home page (#250).

`NouTubeView.goBack` only had two outcomes: navigate back if `canGoBack()` is true, otherwise finish the activity. There was no path that landed the user on the home page first.

When `canGoBack()` is false, check the current path. If we're already on a home root (`/` or empty), finish the activity as before so the user can still close the app from home. Otherwise navigate the WebView to the current host's root (e.g. `https://m.youtube.com/` or `https://music.youtube.com/`) and clear the WebView history once the load completes (via a `pendingClearHistory` flag consumed in `onPageFinished`), so the next back press from home closes the app cleanly instead of bouncing back to the video.

`canGoBack()` paths, share-intent handling, and the "Restore last playing on start" setting are unchanged.

Closes #250