### PR TITLE
[bug] android: keep background playback alive, fix #309

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -30,7 +30,7 @@ module.exports = ({ config }: { config: ExpoConfig }) => {
     },
     android: {
       versionCode,
-      permissions: ['RECORD_AUDIO', 'MODIFY_AUDIO_SETTINGS'],
+      permissions: ['RECORD_AUDIO', 'MODIFY_AUDIO_SETTINGS', 'POST_NOTIFICATIONS', 'WAKE_LOCK'],
       adaptiveIcon: {
         foregroundImage: './assets/images/adaptive-icon.png',
         monochromeImage: './assets/images/monochrome-icon.png',

--- a/content/background-guard.ts
+++ b/content/background-guard.ts
@@ -1,0 +1,115 @@
+import { log } from './utils'
+
+// YouTube stops background playback on purpose: mobile web pauses for
+// non-premium users when it believes the page is hidden, and inactivity
+// prompts ("Video paused. Continue watching?", ytmusic-you-there-renderer)
+// pause after a few hours. The WebView reports itself as always visible, so
+// the page can't tell it is backgrounded — but the native side can, and it
+// mirrors the real app visibility into window.NouTubeBackground
+// (NouTubeView.onWindowVisibilityChanged).
+//
+// While the app is in the background the user cannot reach the page, so a
+// pause that was not commanded through NouTube.pause() (media notification,
+// bluetooth, sleep timer) and is not an audio interruption (call, another
+// app playing — NouTubeI.canAutoResume) can only come from YouTube itself:
+// dismiss the prompt if one is shown and resume.
+
+const PLAYING = 1
+const PAUSED = 2
+
+const bridgeToken = () => window.NouTubeToken || ''
+
+let appPaused = false
+let wasPlaying = false
+let pausedByInterruption = false
+let pausedTicks = 0
+let resumeAttempts = 0
+
+const isBackground = () => window.NouTubeBackground === true
+
+function confirmYouThereDialogs() {
+  // "Continue watching?" prompts. Only click when the dialog has exactly one
+  // button, so a wrong guess is impossible; with more buttons playVideo()
+  // below resumes playback just as well and YouTube drops the prompt itself.
+  for (const selector of ['ytmusic-you-there-renderer', 'ytm-confirm-dialog-renderer']) {
+    const dialog = document.querySelector(selector)
+    if (!dialog) {
+      continue
+    }
+    const buttons = dialog.querySelectorAll('button')
+    if (buttons.length === 1) {
+      ;(buttons[0] as HTMLElement).click()
+    }
+    return true
+  }
+  return false
+}
+
+export function installBackgroundGuard() {
+  // Track pauses the app itself asked for (media notification, bluetooth,
+  // sleep timer): those episodes are never fought, however long they last.
+  const nouTube = window.NouTube as any
+  if (nouTube && !nouTube.__nouGuardedPause) {
+    const originalPause = nouTube.pause.bind(nouTube)
+    const originalPlay = nouTube.play.bind(nouTube)
+    nouTube.pause = () => {
+      appPaused = true
+      return originalPause()
+    }
+    nouTube.play = () => {
+      appPaused = false
+      return originalPlay()
+    }
+    nouTube.__nouGuardedPause = true
+  }
+
+  setInterval(() => {
+    const player = document.getElementById('movie_player') as any
+    if (!player?.getPlayerState) {
+      return
+    }
+
+    const state = player.getPlayerState()
+    if (state === PLAYING) {
+      appPaused = false
+      wasPlaying = true
+      pausedByInterruption = false
+      pausedTicks = 0
+      resumeAttempts = 0
+      return
+    }
+
+    if (!isBackground()) {
+      // The user can interact with the page again; whatever is paused now is
+      // their business.
+      wasPlaying = false
+      pausedByInterruption = false
+      pausedTicks = 0
+      resumeAttempts = 0
+      return
+    }
+
+    if (state !== PAUSED || !wasPlaying || appPaused || pausedByInterruption) {
+      return
+    }
+    pausedTicks++
+    if (resumeAttempts >= 3) {
+      return
+    }
+    if (window.NouTubeI?.canAutoResume?.(bridgeToken()) === false) {
+      // Our own stream lingers as "active" for ~10s after a pause, so give it
+      // a few ticks to clear. Still blocked after that means a call or another
+      // app really took the audio over: stay paused for good — if the
+      // interruption ends, the user resumes from the media notification, not us.
+      if (pausedTicks >= 6) {
+        pausedByInterruption = true
+      }
+      return
+    }
+
+    resumeAttempts++
+    const dismissed = confirmYouThereDialogs()
+    log(`background guard: resuming (attempt ${resumeAttempts}, dialog: ${dismissed})`)
+    player.playVideo?.()
+  }, 5000)
+}

--- a/content/main.ts
+++ b/content/main.ts
@@ -18,6 +18,7 @@ import { installWatchNavigation } from './watch-nav'
 import { installFullscreenControls } from './fullscreen-controls'
 import { installSystemCaptionStyle } from './captions'
 import { installEncodedAuthorNameFix } from './author-names'
+import { installBackgroundGuard } from './background-guard'
 
 try {
   if ((window as any).NouTubePreferH264) {
@@ -60,7 +61,10 @@ try {
     })
   }
 
-  setInterval(() => (window._lact = Date.now()), 20 * 60 * 1000)
+  // YouTube pauses playback with a "Continue watching?" prompt once _lact goes
+  // stale for hours. Refreshing it every minute keeps the session active for
+  // the whole background playback, not just the first prompt interval.
+  setInterval(() => (window._lact = Date.now()), 60 * 1000)
 } catch (e) {
   console.error('NouScript: ', e)
 }
@@ -88,6 +92,9 @@ async function initObserver() {
   installFullscreenControls()
   installCommentTranslateButtons()
   installEncodedAuthorNameFix()
+  if (window.isAndroid) {
+    installBackgroundGuard()
+  }
 
   pinchToZoom()
 }

--- a/content/types.ts
+++ b/content/types.ts
@@ -11,6 +11,7 @@ interface NouTubeI {
   getVolumeSteps?: (token: string) => number
   getVolumeIndex?: (token: string) => number
   setVolumeIndex?: (token: string, index: number) => void
+  canAutoResume?: (token: string) => boolean
 }
 
 declare global {
@@ -22,6 +23,9 @@ declare global {
     NouTubeUserStyles?: import('../lib/user-styles').UserStylesSnapshot
     NouTubeI: NouTubeI
     NouTubeToken?: string
+    // Real app visibility fed by NouTubeView.onWindowVisibilityChanged; the
+    // page itself always reports "visible" (see NouWebView).
+    NouTubeBackground?: boolean
     NouTube: any
     trustedTypes: any
     electron: ElectronAPI

--- a/modules/nou-tube-view/android/src/main/java/expo/modules/noutubeview/NouJsInterface.kt
+++ b/modules/nou-tube-view/android/src/main/java/expo/modules/noutubeview/NouJsInterface.kt
@@ -38,6 +38,13 @@ class NouJsInterface(private val context: Context, private val view: NouTubeView
   @JavascriptInterface
   fun getBrightness(token: String?): Float = if (view.isBridgeTokenValid(token)) view.getBrightness() else -1f
 
+  // Whether the background playback guard may resume a pause it did not cause:
+  // false during calls or while another app holds the music stream, so the
+  // guard never fights a real audio interruption (content/background-guard.ts).
+  @JavascriptInterface
+  fun canAutoResume(token: String?): Boolean =
+    if (view.isBridgeTokenValid(token)) view.canAutoResume() else false
+
   // The media stream is stepped, not continuous, so the panel drives it by
   // index instead of by percent.
   @JavascriptInterface

--- a/modules/nou-tube-view/android/src/main/java/expo/modules/noutubeview/NouService.kt
+++ b/modules/nou-tube-view/android/src/main/java/expo/modules/noutubeview/NouService.kt
@@ -11,9 +11,11 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.ServiceInfo
 import android.graphics.BitmapFactory
 import android.media.AudioManager
 import android.os.Binder
+import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import android.os.Handler
@@ -50,8 +52,10 @@ class NouService : Service() {
   private val mainHandler = Handler(Looper.getMainLooper())
   private var sleepTimerDeadlineMs: Long? = null
   private var sleepTimerRunnable: Runnable? = null
+  private var lastForegroundAssertMs = 0L
   private val NOTIFICATION_ID = 777
   private val CHANNEL_ID = "noutube"
+  private val FOREGROUND_REASSERT_INTERVAL_MS = 60_000L
 
   inner class NouBinder : Binder() {
     fun getService(): NouService = this@NouService
@@ -59,11 +63,15 @@ class NouService : Service() {
 
   override fun onBind(intent: Intent): IBinder = binder
 
-  override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+  // The intent is null when the service is restarted by the system.
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
     if (intent != null) {
       MediaButtonReceiver.handleIntent(mediaSession, intent)
     }
-    return super.onStartCommand(intent, flags, startId)
+    // Never restart a dead process just for this service: without the activity
+    // and its WebView there is nothing to play. While the activity lives, its
+    // BIND_AUTO_CREATE binding recreates the service on demand anyway.
+    return START_NOT_STICKY
   }
 
   fun initialize(view: NouWebView, _activity: Activity) {
@@ -155,10 +163,12 @@ class NouService : Service() {
 
   fun buildNotification(): Notification {
     val session = mediaSession!!
+    // Metadata is null when the service got restarted and no video change has
+    // happened yet; the notification must still build so ensureForeground works.
     val metadata = session.getController().getMetadata()
-    val title = metadata.getString(MediaMetadataCompat.METADATA_KEY_TITLE)
-    val author = metadata.getString(MediaMetadataCompat.METADATA_KEY_ARTIST)
-    val largeIcon = metadata.getBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART)
+    val title = metadata?.getString(MediaMetadataCompat.METADATA_KEY_TITLE) ?: "NouTube"
+    val author = metadata?.getString(MediaMetadataCompat.METADATA_KEY_ARTIST) ?: ""
+    val largeIcon = metadata?.getBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART)
     val playActionIntent =
       MediaButtonReceiver.buildMediaButtonPendingIntent(
         this,
@@ -226,6 +236,48 @@ class NouService : Service() {
     mediaSession?.setPlaybackState(state)
   }
 
+  private fun ensureNotificationManager() {
+    if (notificationManager == null) {
+      val channel = NotificationChannel(CHANNEL_ID, "NouTube", NotificationManager.IMPORTANCE_LOW)
+      channel.setLockscreenVisibility(Notification.VISIBILITY_PUBLIC)
+
+      notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+      notificationManager?.createNotificationChannel(channel)
+    }
+  }
+
+  // The system can silently drop the service's foreground state while the app
+  // is in the background (observed on Android 17: FOREGROUND_SERVICE_STOP
+  // ~18min after backgrounding, with the process and binding alive). A cached
+  // app playing audio is then fair game for the background-CPU killer, which
+  // ends up shooting the WebView renderer mid-playback (#309, #146, #206).
+  // The demotion happens without any callback, so while playback is running,
+  // re-assert the foreground state at least once a minute.
+  private fun ensureForeground() {
+    if (mediaSession == null) {
+      return
+    }
+    val now = SystemClock.elapsedRealtime()
+    if (now - lastForegroundAssertMs < FOREGROUND_REASSERT_INTERVAL_MS) {
+      return
+    }
+    lastForegroundAssertMs = now
+    try {
+      ensureNotificationManager()
+      val notification = buildNotification()
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+      } else {
+        startForeground(NOTIFICATION_ID, notification)
+      }
+    } catch (e: Exception) {
+      // ForegroundServiceStartNotAllowedException and friends: keep playing,
+      // retry on the next tick after the interval or when the app is
+      // foregrounded again.
+      nouController.log("startForeground failed: ${e.message}")
+    }
+  }
+
   fun notify(title: String, author: String, seconds: Long, thumbnail: String) {
     val metadataBuilder = MediaMetadataCompat.Builder()
       .putString(MediaMetadataCompat.METADATA_KEY_TITLE, title)
@@ -247,32 +299,35 @@ class NouService : Service() {
       }
     }
     mediaSession?.setMetadata(metadataBuilder.build())
-    val notification = buildNotification()
-    if (notificationManager == null) {
-      val channel = NotificationChannel(CHANNEL_ID, "NouTube", NotificationManager.IMPORTANCE_LOW)
-      channel.setLockscreenVisibility(Notification.VISIBILITY_PUBLIC)
-
-      notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-      notificationManager?.createNotificationChannel(channel)
-      startForeground(NOTIFICATION_ID, notification)
-    }
+    ensureForeground()
     notificationManager?.notify(
       NOTIFICATION_ID,
-      notification
+      buildNotification()
     )
   }
 
   fun notifyProgress(playing: Boolean, pos: Long) {
     val statePlaying = mediaSession?.getController()?.getPlaybackState()?.state == PlaybackStateCompat.STATE_PLAYING
     setPlaybackState(playing, pos)
+    if (playing) {
+      ensureForeground()
+    }
     if (statePlaying != playing) {
       notificationManager?.notify(NOTIFICATION_ID, buildNotification())
     }
   }
 
+  override fun onTaskRemoved(rootIntent: Intent?) {
+    // The service is started (not only bound), so swiping the app away no
+    // longer stops it implicitly. Mirror the old behavior: no app, no player.
+    exit()
+    super.onTaskRemoved(rootIntent)
+  }
+
   fun exit() {
     clearSleepTimer(false)
     stopForeground(STOP_FOREGROUND_REMOVE)
+    lastForegroundAssertMs = 0L
     notificationManager?.cancel(NOTIFICATION_ID)
     notificationManager = null
     mediaSession?.setActive(false)

--- a/modules/nou-tube-view/android/src/main/java/expo/modules/noutubeview/NouTubeView.kt
+++ b/modules/nou-tube-view/android/src/main/java/expo/modules/noutubeview/NouTubeView.kt
@@ -79,6 +79,13 @@ class NouWebView @JvmOverloads constructor(context: Context, attrs: AttributeSet
     }
     CookieManager.getInstance().setAcceptCookie(true)
 
+    // The default policy waives the renderer priority when the WebView is not
+    // visible, leaving the renderer at cached importance in the background
+    // where the system may kill it for using CPU while playing audio (#309).
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+      setRendererPriorityPolicy(RENDERER_PRIORITY_IMPORTANT, false)
+    }
+
     // https://stackoverflow.com/a/64564676
     setFocusable(true)
     setFocusableInTouchMode(true)
@@ -114,6 +121,7 @@ class NouTubeView(context: Context, appContext: AppContext) : ExpoView(context, 
   private val bridgeToken = UUID.randomUUID().toString()
 
   internal fun isBridgeTokenValid(token: String?) = token == bridgeToken
+  private var isWindowInBackground = false
   private var pageUrl = ""
   private var customView: View? = null
   private var pullToRefreshEnabled = true
@@ -205,7 +213,12 @@ class NouTubeView(context: Context, appContext: AppContext) : ExpoView(context, 
           }
 
           override fun onPageStarted(view: WebView, url: String, favicon: Bitmap?) {
-            evaluateJavascript("window.NouTubeToken = '$bridgeToken';$scriptOnStart", null)
+            // NouTubeBackground must survive navigations (the queue advances in
+            // the background), so seed every new document with the current value.
+            evaluateJavascript(
+              "window.NouTubeToken = '$bridgeToken';window.NouTubeBackground = $isWindowInBackground;$scriptOnStart",
+              null
+            )
           }
 
           override fun onPageFinished(view: WebView, url: String) {
@@ -381,6 +394,17 @@ class NouTubeView(context: Context, appContext: AppContext) : ExpoView(context, 
     }
   }
 
+  // NouWebView fakes its own window visibility so the page never pauses, which
+  // also blinds the page to being backgrounded. This container sees the real
+  // value; hand it to the page so the background playback guard only fights
+  // YouTube's background pauses, never a user's own pause (see
+  // content/background-guard.ts).
+  override fun onWindowVisibilityChanged(visibility: Int) {
+    super.onWindowVisibilityChanged(visibility)
+    isWindowInBackground = visibility != View.VISIBLE
+    webView.evaluateJavascript("window.NouTubeBackground = $isWindowInBackground", null)
+  }
+
   // Consuming the insets above also zeroes env(safe-area-inset-*) in the page,
   // but fullscreen overlays still have to dodge the display cutout: fullscreen
   // draws under it (targetSdk 35+ defaults to LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS)
@@ -415,6 +439,16 @@ class NouTubeView(context: Context, appContext: AppContext) : ExpoView(context, 
     if (activity == null) {
       return
     }
+
+    // The media notification is invisible without this on Android 13+, and the
+    // app never surfaces in the system media controls ("not a music app", #309).
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU &&
+      activity.checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS) !=
+      android.content.pm.PackageManager.PERMISSION_GRANTED
+    ) {
+      activity.requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), 102)
+    }
+
     val connection = object : ServiceConnection {
       override fun onServiceConnected(name: ComponentName, binder: IBinder) {
         val nouBinder = binder as NouService.NouBinder
@@ -428,6 +462,15 @@ class NouTubeView(context: Context, appContext: AppContext) : ExpoView(context, 
       }
     }
     val intent = Intent(activity, NouService::class.java)
+    // Start the service in addition to binding it. A bound-only service loses
+    // its foreground state more easily; a started one keeps it until exit(),
+    // and if the system stops the service anyway, the binding recreates it and
+    // ensureForeground re-promotes it on the next playing progress tick.
+    try {
+      activity.startService(intent)
+    } catch (e: Exception) {
+      // Background start restrictions: binding below still works.
+    }
     activity.bindService(intent, connection, Context.BIND_AUTO_CREATE)
 
     orientationListener = NouOrientationListener(activity, this)
@@ -471,6 +514,15 @@ class NouTubeView(context: Context, appContext: AppContext) : ExpoView(context, 
 
   private val audioManager: AudioManager
     get() = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+  // A pause is only auto-resumable when it cannot be an audio interruption:
+  // no ongoing call/ring/VoIP and no other app playing on the music stream.
+  fun canAutoResume(): Boolean =
+    try {
+      audioManager.mode == AudioManager.MODE_NORMAL && !audioManager.isMusicActive
+    } catch (e: Exception) {
+      false
+    }
 
   fun getVolumeSteps(): Int =
     try {


### PR DESCRIPTION
## What was happening

Debugged live on a Pixel 10 Pro XL (Android 17) that reproduces #309, with every setting users were told to check already correct (battery unrestricted, Doze-whitelisted, background data on). System event history of one failing session (usagestats + batterystats + ApplicationExitInfo):

```
09:53:04  FOREGROUND_SERVICE_START      playback starts, NouService goes foreground
10:10:42  ACTIVITY_STOPPED              app minimized, music playing
10:28:29  FOREGROUND_SERVICE_STOP       ~18 min later the system silently drops the
                                        foreground state (no user action, process alive)
10:28-13:19                             music keeps playing from a cached-importance app
13:19:37  -longwake AudioMix            playback dies ~3h into background playback
16:52:23  renderer killed               "excessive cpu 8300 during 300167 limit=2" -
                                        the background-CPU killer shoots the WebView
                                        renderer at cached importance
```

procstats agrees: the app spent only ~0.6% of the day in the Fgs state despite hours of background playback. Three compounding problems:

1. **The foreground service does not stay foreground.** `startForeground` runs once per session and nothing re-asserts it after the system drops it (and a later re-promotion attempt from the background throws `ForegroundServiceStartNotAllowedException`, which nothing caught — a service crash, which I suspect is #146's "soft crash"). Once demoted, the app and its WebView renderer idle at cached importance while playing, where the background-CPU killer and OEM policies are free to shoot them. Matches "stops after a while" with the delay varying per device.

2. **The media notification is invisible on Android 13+.** `POST_NOTIFICATIONS` was never declared or requested, so the MediaStyle notification is suppressed (`appops get … POST_NOTIFICATION` → `ignore` on a fresh install): no media controls anywhere, "noutube doesn't show up as a music app" (comment in #309), and the media FGS runs notification-less — exactly the kind recent Android versions demote.

3. **YouTube itself stops background playback.** Reproduced on a clean Android 16 emulator with 0.6.8: ~20 minutes into backgrounded playback of a long video, m.youtube.com pauses with **"Video paused. Continue watching?"** (single **Yes** button). It fired while `window._lact` was fresh (~53s old), so the existing `_lact` refresh cannot prevent it on fresh profiles; established/logged-in sessions hit the same prompt after ~2-4h — which lines up with the 13:19:37 stop above and the "stops after ~3 hours" reports.

## What this PR changes

Native (`nou-tube-view`):
- `NouService.ensureForeground()`: re-asserts `startForeground` (with `FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK` on Q+) at most once a minute while playback progresses, so a silent demotion never outlives the next minute of playback. Rejections are caught and logged instead of crashing the service.
- The service is now started (`startService`) in addition to bound, returns `START_NOT_STICKY` (`onStartCommand` now also survives the null restart intent, which would have NPE'd before), and exits in `onTaskRemoved` to keep the old swipe-away-stops-everything behavior.
- `buildNotification()` no longer NPEs when metadata hasn't arrived yet (restarted session).
- `POST_NOTIFICATIONS` + `WAKE_LOCK` declared; the notification permission is requested on startup (Android 13+). WAKE_LOCK lets Chromium's media stack hold its own playback wake lock.
- `setRendererPriorityPolicy(RENDERER_PRIORITY_IMPORTANT, false)`: the default policy waives the renderer priority when the WebView is "not visible", which left the renderer killable.
- `NouTubeView.onWindowVisibilityChanged` mirrors the *real* app visibility into `window.NouTubeBackground` (seeded into every new document, so it survives queue navigations; the WebView itself keeps faking "visible" as before so the page never throttles).

Content scripts:
- `background-guard.ts` (new): while the app is really in the background, a pause that was not commanded through `NouTube.pause()` (media notification, bluetooth, sleep timer) and is not an audio interruption (call / another app playing — checked natively via `NouTubeI.canAutoResume`, with a grace window because our own stream reports active for ~10s after a pause) can only be YouTube stopping playback: confirm the "Continue watching?" dialog if present (only when it has exactly one button, so a wrong guess is impossible) and resume, max 3 attempts per episode. User pauses stay paused for good.
- `_lact` refresh bumped from every 20 min to every minute.

## Verified on an Android 16 emulator (fullRelease build)

- media notification now shows with full controls, artwork and the output switcher — NouTube appears as a proper media app,
- simulated YouTube-pause while backgrounded+screen off → auto-resumed in ~15 s (`background guard: resuming (attempt 1…)` in the log),
- pause from the media notification stays paused (>90 s observed), resume from it re-arms the guard,
- with `START_FOREGROUND` app-op force-denied, the once-a-minute re-assert logs `startForeground failed: … mAllowStartForeground false` and playback continues — previously this path was an uncaught service crash,
- `bun test` (157 passing), `expo lint`, and both `full`/`foss` Kotlin flavors compile.

Fixes #309; the same root causes look responsible for #146 and #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
